### PR TITLE
Add enchantment tags for Magiccloth armor

### DIFF
--- a/src/main/java/com/gilfort/zauberei/datagen/ZaubereiItemTagProvider.java
+++ b/src/main/java/com/gilfort/zauberei/datagen/ZaubereiItemTagProvider.java
@@ -1,11 +1,13 @@
 package com.gilfort.zauberei.datagen;
 
 import com.gilfort.zauberei.Zauberei;
+import com.gilfort.zauberei.item.ZaubereiItems;
 import com.gilfort.zauberei.util.ZaubereiTags;
 import net.minecraft.core.HolderLookup;
 import net.minecraft.data.PackOutput;
 import net.minecraft.data.tags.ItemTagsProvider;
-import net.minecraft.world.item.Items;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.tags.ItemTags;
 import net.minecraft.world.level.block.Block;
 import net.neoforged.neoforge.common.data.ExistingFileHelper;
 import org.jetbrains.annotations.Nullable;
@@ -20,13 +22,43 @@ public class ZaubereiItemTagProvider extends ItemTagsProvider {
 
     @Override
     protected void addTags(HolderLookup.Provider provider) {
-        tag(ZaubereiTags.Items.TRANSFORMABLE_ITEMS)
-//                .add(ModItems.BISMUTH.get())
-//                .add(ModItems.RAW_BISMUTH.get())
-//                .add(Items.COAL)
-//                .add(Items.STICK)
-//                .add(Items.COMPASS);
-        ;
+        tag(ItemTags.create(ResourceLocation.fromNamespaceAndPath("minecraft", "enchantable/armor")))
+                .add(
+                        ZaubereiItems.MAGICCLOTH_HELMET.get(),
+                        ZaubereiItems.MAGICCLOTH_HELMET_ALT.get(),
+                        ZaubereiItems.MAGICCLOTH_CHESTPLATE.get(),
+                        ZaubereiItems.MAGICCLOTH_CHESTPLATE_ALT.get(),
+                        ZaubereiItems.MAGICCLOTH_LEGGINGS.get(),
+                        ZaubereiItems.MAGICCLOTH_LEGGINGS_ALT.get(),
+                        ZaubereiItems.MAGICCLOTH_BOOTS.get(),
+                        ZaubereiItems.MAGICCLOTH_BOOTS_ALT.get()
+                );
+
+        tag(ItemTags.create(ResourceLocation.fromNamespaceAndPath("minecraft", "enchantable/helmet")))
+                .add(
+                        ZaubereiItems.MAGICCLOTH_HELMET.get(),
+                        ZaubereiItems.MAGICCLOTH_HELMET_ALT.get()
+                );
+
+        tag(ItemTags.create(ResourceLocation.fromNamespaceAndPath("minecraft", "enchantable/chestplate")))
+                .add(
+                        ZaubereiItems.MAGICCLOTH_CHESTPLATE.get(),
+                        ZaubereiItems.MAGICCLOTH_CHESTPLATE_ALT.get()
+                );
+
+        tag(ItemTags.create(ResourceLocation.fromNamespaceAndPath("minecraft", "enchantable/leggings")))
+                .add(
+                        ZaubereiItems.MAGICCLOTH_LEGGINGS.get(),
+                        ZaubereiItems.MAGICCLOTH_LEGGINGS_ALT.get()
+                );
+
+        tag(ItemTags.create(ResourceLocation.fromNamespaceAndPath("minecraft", "enchantable/boots")))
+                .add(
+                        ZaubereiItems.MAGICCLOTH_BOOTS.get(),
+                        ZaubereiItems.MAGICCLOTH_BOOTS_ALT.get()
+                );
+
+        tag(ZaubereiTags.Items.TRANSFORMABLE_ITEMS);
 
     }
 }

--- a/src/main/resources/data/minecraft/tags/items/enchantable/armor.json
+++ b/src/main/resources/data/minecraft/tags/items/enchantable/armor.json
@@ -1,0 +1,13 @@
+{
+  "replace": false,
+  "values": [
+    "zauberei:magiccloth_helmet",
+    "zauberei:magiccloth_helmet_alt",
+    "zauberei:magiccloth_chestplate",
+    "zauberei:magiccloth_chestplate_alt",
+    "zauberei:magiccloth_leggings",
+    "zauberei:magiccloth_leggings_alt",
+    "zauberei:magiccloth_boots",
+    "zauberei:magiccloth_boots_alt"
+  ]
+}

--- a/src/main/resources/data/minecraft/tags/items/enchantable/boots.json
+++ b/src/main/resources/data/minecraft/tags/items/enchantable/boots.json
@@ -1,0 +1,7 @@
+{
+  "replace": false,
+  "values": [
+    "zauberei:magiccloth_boots",
+    "zauberei:magiccloth_boots_alt"
+  ]
+}

--- a/src/main/resources/data/minecraft/tags/items/enchantable/chestplate.json
+++ b/src/main/resources/data/minecraft/tags/items/enchantable/chestplate.json
@@ -1,0 +1,7 @@
+{
+  "replace": false,
+  "values": [
+    "zauberei:magiccloth_chestplate",
+    "zauberei:magiccloth_chestplate_alt"
+  ]
+}

--- a/src/main/resources/data/minecraft/tags/items/enchantable/helmet.json
+++ b/src/main/resources/data/minecraft/tags/items/enchantable/helmet.json
@@ -1,0 +1,7 @@
+{
+  "replace": false,
+  "values": [
+    "zauberei:magiccloth_helmet",
+    "zauberei:magiccloth_helmet_alt"
+  ]
+}

--- a/src/main/resources/data/minecraft/tags/items/enchantable/leggings.json
+++ b/src/main/resources/data/minecraft/tags/items/enchantable/leggings.json
@@ -1,0 +1,7 @@
+{
+  "replace": false,
+  "values": [
+    "zauberei:magiccloth_leggings",
+    "zauberei:magiccloth_leggings_alt"
+  ]
+}


### PR DESCRIPTION
## Summary
- tag Magiccloth armor items so they can be enchanted like standard armor
- define enchantable tag JSONs for armor pieces

## Testing
- `./gradlew build`

------
https://chatgpt.com/codex/tasks/task_e_68a99be901a48322ad43d3586e559224