### PR TITLE
refactor: remove event bus subscriber annotation

### DIFF
--- a/src/main/java/com/gilfort/zauberei/commands/CommandsService.java
+++ b/src/main/java/com/gilfort/zauberei/commands/CommandsService.java
@@ -9,7 +9,6 @@ import net.minecraft.core.BlockPos;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.server.level.ServerPlayer;
 import net.neoforged.bus.api.SubscribeEvent;
-import net.neoforged.fml.common.EventBusSubscriber;
 import net.neoforged.neoforge.common.NeoForge;
 import net.neoforged.neoforge.event.RegisterCommandsEvent;
 import net.neoforged.neoforge.event.entity.player.AdvancementEvent;
@@ -21,7 +20,6 @@ import java.util.*;
 import java.util.concurrent.ThreadLocalRandom;
 
 /** Service managing per-player timers and command execution. */
-@EventBusSubscriber
 public class CommandsService {
     private static final CommandsService INSTANCE = new CommandsService();
 


### PR DESCRIPTION
## Summary
- remove @EventBusSubscriber annotation and import from CommandsService
- rely on explicit NeoForge event bus registration via CommandsService.init()

## Testing
- ❌ `./gradlew test` (failed: Could not resolve net.neoforged:neoforge:21.1.144, received status code 403)


------
https://chatgpt.com/codex/tasks/task_e_68aa26b5938883228bf47ac174f994ef