### PR TITLE
Handle ResourceLocation strings in gateway config

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -18,7 +18,7 @@ minecraft_version=1.21.1
 # as they do not follow standard versioning conventions.
 minecraft_version_range=[1.21.1, 1.22)
 # The Neo version must agree with the Minecraft version to get a valid artifact
-neo_version=21.1.144
+neo_version=21.1.187
 # The Neo version range can use any version of Neo as bounds
 neo_version_range=[21.1.0,)
 # The loader version range can only use the major version of FML as bounds

--- a/src/main/java/com/gilfort/zauberei/Zauberei.java
+++ b/src/main/java/com/gilfort/zauberei/Zauberei.java
@@ -5,6 +5,7 @@ import com.gilfort.zauberei.creativetab.ZaubereiCreativeModeTabs;
 import com.gilfort.zauberei.item.armor.ArmorEffects;
 import com.gilfort.zauberei.item.ZaubereiItems;
 import com.gilfort.zauberei.item.armor.ZaubereiArmorMaterials;
+import com.gilfort.zauberei.commands.CommandsService;
 import com.gilfort.zauberei.item.armorbonus.ZaubereiReloadListener;
 import com.gilfort.zauberei.structure.ZaubereiStructures;
 import com.gilfort.zauberei.util.ZaubereiPlayerData;
@@ -75,6 +76,7 @@ public class Zauberei
         // Register ourselves for server and other game events we are interested in.
         // Note that this is necessary if and only if we want *this* class (ExampleMod) to respond directly to events.
         // Do not add this line if there are no @SubscribeEvent-annotated functions in this class, like onServerStarting() below.
+        CommandsService.init();
         NeoForge.EVENT_BUS.register(this);
 
         // Register our mod's ModConfigSpec so that FML can create and load the config file for us

--- a/src/main/java/com/gilfort/zauberei/commands/CommandsAdvancementUtil.java
+++ b/src/main/java/com/gilfort/zauberei/commands/CommandsAdvancementUtil.java
@@ -1,0 +1,16 @@
+package com.gilfort.zauberei.commands;
+
+import net.minecraft.advancements.AdvancementHolder;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.server.level.ServerPlayer;
+
+/** Utility around player advancements. */
+public class CommandsAdvancementUtil {
+    public static boolean hasAdv(ServerPlayer player, ResourceLocation id) {
+        AdvancementHolder holder = player.server.getAdvancements().get(id);
+        if (holder == null) {
+            return false;
+        }
+        return player.getAdvancements().getOrStartProgress(holder).isDone();
+    }
+}

--- a/src/main/java/com/gilfort/zauberei/commands/CommandsConfig.java
+++ b/src/main/java/com/gilfort/zauberei/commands/CommandsConfig.java
@@ -1,0 +1,115 @@
+package com.gilfort.zauberei.commands;
+
+import com.gilfort.zauberei.Zauberei;
+import com.google.gson.*;
+import com.google.gson.stream.JsonReader;
+import net.minecraft.resources.ResourceLocation;
+import net.neoforged.fml.loading.FMLPaths;
+
+import java.io.File;
+import java.io.FileReader;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.*;
+
+/**
+ * Loads and validates the JSON configuration for the gateway command system.
+ *
+ * <pre>
+ * {
+ *   "aliases": {"alias": ["namespace:path", ...]},
+ *   "tagRules": [{"anyOf": ["alias"], "allOf": ["alias"], "noneOf": ["alias"], "tag": "name"}],
+ *   "tierRules": [{"anyOf": [...], "tier": 1}],
+ *   "tierWindows": {"1": [minMinutes, maxMinutes], ...},
+ *   "commands": [{
+ *       "when": {"anyTags": ["tag"], "allTags": ["tag"], "minTier": 1},
+ *       "pool": ["command without leading slash"],
+ *       "position": "onPosition|nearby|away" // optional, defaults to nearby
+ *   }]
+ * }
+ * </pre>
+ */
+public class CommandsConfig {
+    public Map<String, List<ResourceLocation>> aliases = new HashMap<>();
+    public List<TagRule> tagRules = new ArrayList<>();
+    public List<TierRule> tierRules = new ArrayList<>();
+    public Map<Integer, int[]> tierWindows = new HashMap<>();
+    public List<CommandEntry> commands = new ArrayList<>();
+
+    public static CommandsConfig load() {
+        Path path = FMLPaths.CONFIGDIR.get().resolve("zauberei").resolve("commands.json5");
+        File file = path.toFile();
+        if (!file.getParentFile().exists()) {
+            file.getParentFile().mkdirs();
+        }
+        if (!file.exists()) {
+            Zauberei.LOGGER.warn("Commands config not found: {}", file.getAbsolutePath());
+            return new CommandsConfig();
+        }
+        Gson gson = new GsonBuilder()
+                .registerTypeAdapter(ResourceLocation.class, (JsonDeserializer<ResourceLocation>)
+                        (json, type, ctx) -> ResourceLocation.parse(json.getAsString()))
+                .create();
+        try (FileReader fr = new FileReader(file)) {
+            JsonReader reader = new JsonReader(fr);
+            reader.setLenient(true);
+            JsonElement root = JsonParser.parseReader(reader);
+            CommandsConfig cfg = gson.fromJson(root, CommandsConfig.class);
+            cfg.postProcess();
+            Zauberei.LOGGER.info("Loaded commands config: {} aliases, {} tagRules, {} tierRules, {} command entries",
+                    cfg.aliases.size(), cfg.tagRules.size(), cfg.tierRules.size(), cfg.commands.size());
+            return cfg;
+        } catch (IOException | JsonParseException e) {
+            Zauberei.LOGGER.error("Failed reading commands config {}: {}", file.getAbsolutePath(), e.getMessage());
+            return new CommandsConfig();
+        }
+    }
+
+    private void postProcess() {
+        if (tierWindows.isEmpty()) {
+            tierWindows.put(1, new int[]{1, 2});
+        }
+        // sanitize command entries to avoid nulls during runtime
+        if (commands != null) {
+            List<CommandEntry> cleaned = new ArrayList<>();
+            for (CommandEntry entry : commands) {
+                if (entry == null) continue;
+                if (entry.when == null) entry.when = new When();
+                if (entry.pool == null) entry.pool = new ArrayList<>();
+                if (entry.position == null || entry.position.isBlank()) {
+                    entry.position = "nearby";
+                }
+                cleaned.add(entry);
+            }
+            commands = cleaned;
+        } else {
+            commands = new ArrayList<>();
+        }
+    }
+
+    public static class TagRule {
+        public List<String> anyOf;
+        public List<String> allOf;
+        public List<String> noneOf;
+        public String tag;
+    }
+
+    public static class TierRule {
+        public List<String> anyOf;
+        public List<String> allOf;
+        public List<String> noneOf;
+        public int tier = 1;
+    }
+
+    public static class CommandEntry {
+        public When when = new When();
+        public List<String> pool = new ArrayList<>();
+        public String position = "nearby";
+    }
+
+    public static class When {
+        public List<String> anyTags;
+        public List<String> allTags;
+        public int minTier = 1;
+    }
+}

--- a/src/main/java/com/gilfort/zauberei/commands/CommandsPlaceholderUtil.java
+++ b/src/main/java/com/gilfort/zauberei/commands/CommandsPlaceholderUtil.java
@@ -1,0 +1,19 @@
+package com.gilfort.zauberei.commands;
+
+import net.minecraft.core.BlockPos;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.world.level.Level;
+
+/** Utility for replacing placeholders in command strings. */
+public class CommandsPlaceholderUtil {
+    public static String apply(String cmd, ServerPlayer player, BlockPos pos) {
+        Level level = player.level();
+        String result = cmd;
+        result = result.replace("{player}", player.getGameProfile().getName());
+        result = result.replace("{x}", Integer.toString(pos.getX()));
+        result = result.replace("{y}", Integer.toString(pos.getY()));
+        result = result.replace("{z}", Integer.toString(pos.getZ()));
+        result = result.replace("{dim}", level.dimension().location().toString());
+        return result;
+    }
+}

--- a/src/main/java/com/gilfort/zauberei/commands/CommandsService.java
+++ b/src/main/java/com/gilfort/zauberei/commands/CommandsService.java
@@ -1,0 +1,281 @@
+package com.gilfort.zauberei.commands;
+
+import com.gilfort.zauberei.Zauberei;
+import com.mojang.brigadier.CommandDispatcher;
+import com.mojang.brigadier.builder.LiteralArgumentBuilder;
+import net.minecraft.commands.CommandSourceStack;
+import net.minecraft.commands.Commands;
+import net.minecraft.core.BlockPos;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.server.level.ServerPlayer;
+import net.neoforged.bus.api.SubscribeEvent;
+import net.neoforged.neoforge.common.NeoForge;
+import net.neoforged.neoforge.event.RegisterCommandsEvent;
+import net.neoforged.neoforge.event.entity.player.AdvancementEvent;
+import net.neoforged.neoforge.event.entity.player.PlayerEvent;
+import net.neoforged.neoforge.event.server.ServerStartingEvent;
+import net.neoforged.neoforge.event.tick.ServerTickEvent;
+
+import java.util.*;
+import java.util.concurrent.ThreadLocalRandom;
+
+/** Service managing per-player timers and command execution. */
+public class CommandsService {
+    private static final CommandsService INSTANCE = new CommandsService();
+
+    private CommandsConfig config = new CommandsConfig();
+    private final Map<UUID, GwState> states = new HashMap<>();
+    private int tickCounter = 0;
+
+    public static void init() {
+        NeoForge.EVENT_BUS.register(INSTANCE);
+    }
+
+    @SubscribeEvent
+    public void onServerStart(ServerStartingEvent e) {
+        config = CommandsConfig.load();
+    }
+
+    @SubscribeEvent
+    public void onRegisterCommands(RegisterCommandsEvent event) {
+        CommandDispatcher<CommandSourceStack> dispatcher = event.getDispatcher();
+        LiteralArgumentBuilder<CommandSourceStack> root = Commands.literal("zauberei").requires(cs -> cs.hasPermission(2));
+        LiteralArgumentBuilder<CommandSourceStack> cmds = Commands.literal("commands");
+
+        cmds.then(Commands.literal("reload").executes(ctx -> {
+            config = CommandsConfig.load();
+            ctx.getSource().sendSuccess(() -> net.minecraft.network.chat.Component.literal("Commands config reloaded"), false);
+            return 1;
+        }));
+
+        cmds.then(Commands.literal("dump").executes(ctx -> {
+            CommandSourceStack src = ctx.getSource();
+            ServerPlayer player = src.getPlayer();
+            if (player == null) return 0;
+            GwState st = states.get(player.getUUID());
+            if (st == null) return 0;
+            Optional<CommandWithPos> next = findMatchingCommand(player, st);
+            src.sendSuccess(() -> net.minecraft.network.chat.Component.literal(
+                    "tier=" + st.tier + " next=" + st.nextInTicks + " tags=" + st.activeTags +
+                            " nextCmd=" + next.map(c -> c.command).orElse("<none>")), false);
+            return 1;
+        }));
+
+        cmds.then(Commands.literal("now").executes(ctx -> {
+            ServerPlayer player = ctx.getSource().getPlayer();
+            if (player == null) return 0;
+            GwState st = states.get(player.getUUID());
+            if (st != null) {
+                st.nextInTicks = 0;
+            }
+            return 1;
+        }));
+
+        root.then(cmds);
+        dispatcher.register(root);
+    }
+
+    @SubscribeEvent
+    public void onPlayerLogin(PlayerEvent.PlayerLoggedInEvent event) {
+        if (!(event.getEntity() instanceof ServerPlayer player)) return;
+        GwState state = CommandsStateCodec.load(player);
+        updateState(player, state);
+        if (state.nextInTicks <= 0) {
+            state.nextInTicks = randomWindow(state.tier);
+        }
+        states.put(player.getUUID(), state);
+    }
+
+    @SubscribeEvent
+    public void onPlayerLogout(PlayerEvent.PlayerLoggedOutEvent event) {
+        if (!(event.getEntity() instanceof ServerPlayer player)) return;
+        GwState state = states.remove(player.getUUID());
+        if (state != null) {
+            CommandsStateCodec.save(player, state);
+        }
+    }
+
+    @SubscribeEvent
+    public void onRespawn(PlayerEvent.PlayerRespawnEvent event) {
+        if (!(event.getEntity() instanceof ServerPlayer player)) return;
+        GwState state = CommandsStateCodec.load(player);
+        updateState(player, state);
+        states.put(player.getUUID(), state);
+    }
+
+    @SubscribeEvent
+    public void onAdvancement(AdvancementEvent.AdvancementEarnEvent event) {
+        if (!(event.getEntity() instanceof ServerPlayer player)) return;
+        GwState state = states.get(player.getUUID());
+        if (state == null) return;
+        updateState(player, state);
+        state.nextInTicks = Math.min(state.nextInTicks, 40); // trigger soon
+    }
+
+    @SubscribeEvent
+    public void onServerTick(ServerTickEvent.Post event) {
+        tickCounter++;
+        if (tickCounter < 20) return;
+        tickCounter = 0;
+        if (event.getServer() == null) return;
+        for (ServerPlayer player : event.getServer().getPlayerList().getPlayers()) {
+            GwState st = states.get(player.getUUID());
+            if (st == null) continue;
+            st.nextInTicks -= 20;
+            if (st.nextInTicks <= 0) {
+                runForPlayer(player, st);
+                st.nextInTicks = randomWindow(st.tier);
+                CommandsStateCodec.save(player, st);
+            }
+        }
+    }
+
+    private void updateState(ServerPlayer player, GwState state) {
+        state.activeTags = computeTags(player);
+        state.tier = computeTier(player, state.activeTags);
+    }
+
+    private Set<String> computeTags(ServerPlayer player) {
+        Set<String> tags = new HashSet<>();
+        for (CommandsConfig.TagRule rule : config.tagRules) {
+            if (rule.tag == null) continue;
+            boolean ok = true;
+            if (rule.anyOf != null && !rule.anyOf.isEmpty()) {
+                ok = false;
+                for (String alias : rule.anyOf) {
+                    if (aliasCompleted(player, alias)) { ok = true; break; }
+                }
+            }
+            if (ok && rule.allOf != null) {
+                for (String alias : rule.allOf) {
+                    if (!aliasCompleted(player, alias)) { ok = false; break; }
+                }
+            }
+            if (ok && rule.noneOf != null) {
+                for (String alias : rule.noneOf) {
+                    if (aliasCompleted(player, alias)) { ok = false; break; }
+                }
+            }
+            if (ok) {
+                tags.add(rule.tag);
+            }
+        }
+        return tags;
+    }
+
+    private int computeTier(ServerPlayer player, Set<String> tags) {
+        int tier = 1;
+        for (CommandsConfig.TierRule rule : config.tierRules) {
+            boolean ok = true;
+            if (rule.anyOf != null && !rule.anyOf.isEmpty()) {
+                ok = false;
+                for (String alias : rule.anyOf) {
+                    if (aliasCompleted(player, alias)) { ok = true; break; }
+                }
+            }
+            if (ok && rule.allOf != null) {
+                for (String alias : rule.allOf) {
+                    if (!aliasCompleted(player, alias)) { ok = false; break; }
+                }
+            }
+            if (ok && rule.noneOf != null) {
+                for (String alias : rule.noneOf) {
+                    if (aliasCompleted(player, alias)) { ok = false; break; }
+                }
+            }
+            if (ok) {
+                tier = Math.max(tier, rule.tier);
+            }
+        }
+        return tier;
+    }
+
+    private boolean aliasCompleted(ServerPlayer player, String alias) {
+        List<ResourceLocation> ids = config.aliases.get(alias);
+        if (ids == null) return false;
+        for (ResourceLocation id : ids) {
+            if (CommandsAdvancementUtil.hasAdv(player, id)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private void runForPlayer(ServerPlayer player, GwState st) {
+        Optional<CommandWithPos> opt = findMatchingCommand(player, st);
+        if (opt.isEmpty()) {
+            return;
+        }
+        CommandWithPos c = opt.get();
+        BlockPos pos = computePosition(player, c.position);
+        String cmd = CommandsPlaceholderUtil.apply(c.command, player, pos);
+        CommandSourceStack src = player.createCommandSourceStack().withPermission(2).withSuppressedOutput();
+        try {
+            player.getServer().getCommands().performPrefixedCommand(src, cmd);
+        } catch (Exception e) {
+            Zauberei.LOGGER.error("Command failed: {}", e.getMessage());
+        }
+    }
+
+    private Optional<CommandWithPos> findMatchingCommand(ServerPlayer player, GwState st) {
+        List<CommandWithPos> pool = new ArrayList<>();
+        if (config.commands != null) {
+            for (CommandsConfig.CommandEntry entry : config.commands) {
+                if (entry == null || entry.when == null || entry.pool == null) continue;
+                if (!matches(entry.when, st)) continue;
+                for (String cmd : entry.pool) {
+                    pool.add(new CommandWithPos(cmd, entry.position));
+                }
+            }
+        }
+        if (pool.isEmpty()) return Optional.empty();
+        return Optional.of(pool.get(ThreadLocalRandom.current().nextInt(pool.size())));
+    }
+
+    private boolean matches(CommandsConfig.When when, GwState st) {
+        if (when == null) return false;
+        if (when.minTier > st.tier) return false;
+        if (when.anyTags != null && !when.anyTags.isEmpty()) {
+            boolean ok = false;
+            for (String tag : when.anyTags) {
+                if (st.activeTags.contains(tag)) { ok = true; break; }
+            }
+            if (!ok) return false;
+        }
+        if (when.allTags != null) {
+            for (String tag : when.allTags) {
+                if (!st.activeTags.contains(tag)) return false;
+            }
+        }
+        return true;
+    }
+
+    private int randomWindow(int tier) {
+        int[] win = config.tierWindows.getOrDefault(tier, config.tierWindows.getOrDefault(1, new int[]{1,2}));
+        int minutes = ThreadLocalRandom.current().nextInt(win[0], win[1] + 1);
+        return minutes * 20 * 60;
+    }
+
+    private BlockPos computePosition(ServerPlayer player, String mode) {
+        BlockPos base = player.blockPosition();
+        if ("onPosition".equalsIgnoreCase(mode)) {
+            return base;
+        }
+        int min = 5;
+        int max = 15;
+        if ("away".equalsIgnoreCase(mode)) {
+            min = 25; max = 35;
+        }
+        double angle = ThreadLocalRandom.current().nextDouble() * Math.PI * 2;
+        double radius = ThreadLocalRandom.current().nextDouble(min, max + 1);
+        int dx = (int)Math.round(Math.cos(angle) * radius);
+        int dz = (int)Math.round(Math.sin(angle) * radius);
+        return base.offset(dx, 0, dz);
+    }
+
+    private static class CommandWithPos {
+        final String command;
+        final String position;
+        CommandWithPos(String cmd, String pos){ this.command = cmd; this.position = pos; }
+    }
+}

--- a/src/main/java/com/gilfort/zauberei/commands/CommandsStateCodec.java
+++ b/src/main/java/com/gilfort/zauberei/commands/CommandsStateCodec.java
@@ -1,0 +1,51 @@
+package com.gilfort.zauberei.commands;
+
+import com.gilfort.zauberei.Zauberei;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.nbt.ListTag;
+import net.minecraft.nbt.StringTag;
+import net.minecraft.nbt.Tag;
+import net.minecraft.server.level.ServerPlayer;
+
+/**
+ * Handles encoding and decoding of {@link GwState} to the player's persistent data.
+ */
+public class CommandsStateCodec {
+    private static final String NBT_KEY = "gw";
+
+    public static GwState load(ServerPlayer player) {
+        CompoundTag data = player.getPersistentData();
+        CompoundTag mod = data.getCompound(Zauberei.MODID);
+        if (!mod.contains(NBT_KEY)) {
+            return new GwState();
+        }
+        CompoundTag tag = mod.getCompound(NBT_KEY);
+        GwState state = new GwState();
+        ListTag tags = tag.getList("tags", Tag.TAG_STRING);
+        for (Tag t : tags) {
+            state.activeTags.add(t.getAsString());
+        }
+        if (tag.contains("tier")) {
+            state.tier = tag.getInt("tier");
+        }
+        if (tag.contains("next")) {
+            state.nextInTicks = tag.getInt("next");
+        }
+        return state;
+    }
+
+    public static void save(ServerPlayer player, GwState state) {
+        CompoundTag data = player.getPersistentData();
+        CompoundTag mod = data.getCompound(Zauberei.MODID);
+        CompoundTag tag = new CompoundTag();
+        ListTag tags = new ListTag();
+        for (String s : state.activeTags) {
+            tags.add(StringTag.valueOf(s));
+        }
+        tag.put("tags", tags);
+        tag.putInt("tier", state.tier);
+        tag.putInt("next", state.nextInTicks);
+        mod.put(NBT_KEY, tag);
+        data.put(Zauberei.MODID, mod);
+    }
+}

--- a/src/main/java/com/gilfort/zauberei/commands/GwState.java
+++ b/src/main/java/com/gilfort/zauberei/commands/GwState.java
@@ -1,0 +1,13 @@
+package com.gilfort.zauberei.commands;
+
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * Per-player runtime state for the gateway command feature.
+ */
+public class GwState {
+    public Set<String> activeTags = new HashSet<>();
+    public int tier = 1;
+    public int nextInTicks = 20 * 60; // default one minute
+}

--- a/src/main/resources/config/zauberei/commands.json5
+++ b/src/main/resources/config/zauberei/commands.json5
@@ -1,0 +1,46 @@
+{
+  "aliases": {
+    "smelt_iron": ["minecraft:story/smelt_iron"],
+    "mine_diamond": ["minecraft:story/mine_diamond"],
+    "kill_mob": ["minecraft:adventure/kill_a_mob"]
+  },
+  "tagRules": [
+    { "anyOf": ["smelt_iron"], "tag": "basic_tasks" },
+    { "anyOf": ["mine_diamond"], "tag": "advanced_tasks" },
+    { "anyOf": ["kill_mob"], "tag": "hunter" }
+  ],
+  "tierRules": [
+    { "anyOf": ["smelt_iron"], "tier": 1 },
+    { "anyOf": ["mine_diamond"], "tier": 2 }
+  ],
+  "tierWindows": {
+    "1": [1, 2],
+    "2": [3, 5],
+    "3": [30, 60]
+  },
+  "commands": [
+    {
+      "when": { "anyTags": ["basic_tasks"], "minTier": 1 },
+      "pool": [
+        "say Hello {player}",
+        "give @s minecraft:bread 1"
+      ],
+      "position": "nearby"
+    },
+    {
+      "when": { "anyTags": ["hunter"], "minTier": 1 },
+      "pool": [
+        "summon minecraft:spider {x} {y} {z}"
+      ],
+      "position": "onPosition"
+    },
+    {
+      "when": { "anyTags": ["advanced_tasks"], "minTier": 2 },
+      "pool": [
+        "give @s minecraft:diamond 64",
+        "effect give {player} minecraft:strength 60 1"
+      ],
+      "position": "away"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- parse `ResourceLocation` values from strings when loading gateway command config
- log and recover from JSON parsing errors during config reload
- drop automatic `@EventBusSubscriber` so command service uses instance handlers
- sanitize command entries to avoid null pointer crashes and guard against malformed matches
- update NeoForge version to 21.1.187

## Testing
- `./gradlew build` *(fails: Could not resolve net.neoforged:neoforge:21.1.187, 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68aa1b86e07083228da7eb8072b505ed